### PR TITLE
make: initial support for meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,52 @@
+project('opensea-common', 'c', license: 'MPL-2.0', version: '1.18.18')
+
+c = meson.get_compiler('c')
+
+if get_option('debug')
+  add_project_arguments('-D_DEBUG', language : 'c')
+endif
+
+global_cpp_args = []
+
+src_files = ['src/common.c', 'src/common_platform.c']
+
+deps = []
+
+# Opensea common defines the nvme header globally and opensea-transport, opensea-operations and openseachest itself include this, so only need to declare it here
+if target_machine.system() == 'linux'
+  src_files += ['src/common_nix.c']
+  if c.check_header('linux/nvme_ioctl.h')
+	global_cpp_args += ['-DSEA_NVME_IOCTL_H']
+  elif c.check_header('linux/nvme.h')
+	global_cpp_args += ['-DSEA_NVME_H']
+  elif c.check_header('uapi/nvme.h')
+	global_cpp_args += ['-DSEA_UAPI_NVME_H']
+  else
+	global_cpp_args += ['-DDISABLE_NVME_PASSTHROUGH']
+  endif
+elif target_machine.system() == 'freebsd'
+  src_files += ['src/common_nix.c']
+  if not c.check_header('dev/nvme/nvme.h')
+	  global_cpp_args += ['-DDISABLE_NVME_PASSTHROUGH']
+  endif
+elif target_machine.system() == 'sunos'
+  src_files += ['src/common_nix.c']
+  global_cpp_args += ['-DDISABLE_NVME_PASSTHROUGH']
+elif target_machine.system() == 'windows'
+  src_files += ['src/common_windows.c']
+  if c.get_define('__MINGW32__') != ''
+	  global_cpp_args += ['-DDISABLE_NVME_PASSTHROUGH', '-DSTRSAFE_NO_DEPRECATE']
+	  win32_version = c.find_library('version')
+	  advapi32 = c.find_library('advapi32')
+	  deps += [win32_version, advapi32]
+  else
+  endif
+  global_cpp_args += ['-DENABLE_CSMI']
+endif # TODO UEFI and vmware
+
+m_dep = c.find_library('m', required : false)
+
+incdir = include_directories('include')
+
+opensea_common_lib = static_library('opensea-common', src_files, c_args : global_cpp_args, dependencies : [m_dep, deps], include_directories : incdir)
+opensea_common_dep = declare_dependency(link_with : opensea_common_lib, compile_args : global_cpp_args, include_directories : incdir)

--- a/src/common.c
+++ b/src/common.c
@@ -73,7 +73,7 @@ void *malloc_aligned(size_t size, size_t alignment)
         return temp;
     #else
 
-    #if !defined(UEFI_C_SOURCE) && defined (__STDC__) && defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    #if !defined(__MINGW32__) && !defined(UEFI_C_SOURCE) && defined (__STDC__) && defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
         //C11 added an aligned alloc function we can use
         //One additional requirement of this function is that the size must be a multiple of alignment, so we will check and round up the size to make this easy.
         if (size % alignment)


### PR DESCRIPTION
The meson build system is a build system with many advantages over others, and one I consider to be the best. It is one of the fastest build systems, has an easy to understand, and extensible syntax (for example a target can be defined to automatically build docs). It supports all platforms the other build systems do (Linux, Windows, FreeBSD) and is easy to use when cross compiling via a cross file (such as with MinGW). It can also programmatically generate the version, instead of needing to edit a header file every time. Compiling openSeaChest on my Linux system, meson (configure) took 0.65s and ninja (build) took 16.62s, while the make-based build system took 30.22s.
See https://mesonbuild.com/Overview.html and https://mesonbuild.com/Comparisons.html for more info on the meson build system.
Note: existing build systems can still be used.

[Seagate/openSeaChest#2]

This PR also fixes building with MinGW with \_\_STDC_VERSION\_\_ >= 201112L