### PR TITLE
quick: fix compilation on macOS

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -55,7 +55,7 @@ extern "C"
     // Including strings.h to have string case compare functionality and working around Windows.
     // TODO: improve this check as needed for other systems.
     // TODO: make definitions for other functions in strings.h
-    #if defined (__unix__) || defined (_POSIX_VERSION) && _POSIX_VERSION >= 200112L
+    #if defined (__unix__) || defined (_POSIX_VERSION) && _POSIX_VERSION >= 200112L || defined (__APPLE__)
         #include <strings.h>
     #elif defined (_WIN32) 
         #if !defined (strcasecmp)

--- a/src/common_nix.c
+++ b/src/common_nix.c
@@ -36,7 +36,8 @@
 #include <stdlib.h>//getenv and related vars.
 
 //freeBSD doesn't have the 64 versions of these functions...so I'm defining things this way to make it work. - TJE
-#if defined(__FreeBSD__)
+//stat64 and friends are deprecated on macOS - fall back to stat/fstat there as well
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #define stat64 stat
 #define fstat64 fstat
 #endif


### PR DESCRIPTION
Small fix to include strings.h and call `fstat` instead of `fstat64` on macOS. `fstat64` is deprecated on macOS and not always available.

Tested on an M1 Macbook, Apple clang 15.0.0