### PR TITLE
bug: fix buffer length overflow in pattern buffer fill

### DIFF
--- a/src/pattern_utils.c
+++ b/src/pattern_utils.c
@@ -90,7 +90,7 @@ eReturnValues fill_ASCII_Pattern_In_Buffer(const char* asciiPattern,
     RESTORE_NONNULL_COMPARE
     for (uint32_t iter = UINT32_C(0); iter < dataLength; iter += patternLength)
     {
-        safe_memcpy(&ptrData[iter], dataLength, asciiPattern, M_Min(patternLength, dataLength - iter));
+        safe_memcpy(&ptrData[iter], dataLength - iter, asciiPattern, M_Min(patternLength, dataLength - iter));
     }
     return SUCCESS;
 }
@@ -108,7 +108,7 @@ eReturnValues fill_Pattern_Buffer_Into_Another_Buffer(uint8_t* inPattern,
     RESTORE_NONNULL_COMPARE
     for (uint32_t iter = UINT32_C(0); iter < dataLength; iter += inpatternLength)
     {
-        safe_memcpy(&ptrData[iter], dataLength, inPattern, M_Min(inpatternLength, dataLength - iter));
+        safe_memcpy(&ptrData[iter], dataLength - iter, inPattern, M_Min(inpatternLength, dataLength - iter));
     }
     return SUCCESS;
 }


### PR DESCRIPTION
If format using `openSeaChest_Format -d /dev/sdX --formatUnit current --pattern repeat:helloword --confirm this-will-erase-data`, it will report following error:
![putty_6cJBMHdZ9J](https://github.com/user-attachments/assets/ade604cf-546a-43df-8879-770d9c3a87bc)

The bug is introduced in https://github.com/Seagate/opensea-common/commit/1963624ab7bcaa87b82090bb8c775bacb1ed8d06#diff-5995a49dc87fd874c3cfa992d1d2fc2dbe2712e2c52f110c85b97aeec96b526f

This function fills a buffer repeatly. In every loop, `&ptrData[iter]` moves forward by increasing `patternLength` every time, but second argument for safe_memcpy which is destination length keeps a static value `dataLength`, finally `&ptrData[iter] + dataLength` will exceed boundary of `ptrData + dataLength` and overlap with other variables, and cause memory issue.

I only fixed the two occurrences in `src/pattern_utils.c` only. I think original commit needs a full review in case such issue exists in any other file.