### PR TITLE
Clang tidy enhancements and cleanup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,20 +1,32 @@
 Checks: 
   '-*, 
   modernize-*, 
+  -modernize-macro-to-enum,
   cert-*, 
   bugprone-*, 
   -bugprone-easily-swappable-parameters, 
+  -bugprone-assignment-in-if-condition,
   clang-analyzer-*, 
   -clang-analyzer-deadcode.DeadStores, 
   misc-*, 
   -misc-no-recursion, 
   -misc-unused-parameters, 
+  -misc-include-cleaner,
   readability-non-const-parameter, 
   readability-inconsistent-declaration-parameter-name, 
   readability-redundant-control-flow, 
   readability-duplicate-include, 
   readability-avoid-const-params-in-decls, 
   readability-function-cognitive-complexity'
+
+# Setting cognitive complexity to 100.
+# This is quite high, but should be seen as a starting point
+# to resolve other complex functions over time to get back to the default
+# value of 25
+CheckOptions:
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 100
+
 
 # Other available checks: 
 # clang-analyzer-*, performance-*, readability-*, misc-*
@@ -29,10 +41,17 @@ Checks:
 #   Recursion is useful in our code, so this check is not applicable.
 # - misc-unused-parameters: 
 #   Too many false positives.
+# - misc-include-cleaner
+#   We have a lot of includes wrapping others to work around system differences. This creates too much noise
+#   when it is enabled.
+# - modernize-macro-to-enum
+#   This is a great modernization, however it does not make sense everywhere.
+#   There are plenty of places to use this, however since we do not want to migrate to C11 as a requirement
+#   yet, this is not something we want to enable due to noise since anonymous enums are a C11 standard and not earlier.
+#   if/when we require C11, we should enable this
 # - readability-*: 
 #   Currently generates too many warnings. Manually adding rules until we can address these issues later.
 
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
-AnalyzeTemporaryDtors: false
 FormatStyle: 'file'

--- a/include/bit_manip.h
+++ b/include/bit_manip.h
@@ -93,19 +93,19 @@ extern "C"
 #define M_DoubleWordInt1(l) (M_STATIC_CAST(int32_t, (((l) & UINT64_C(0xFFFFFFFF00000000)) >> 32)))
 
 #if defined(HAVE_C11_GENERIC_SELECTION)
-//! \fn get_Word0_uint64(uint64_t value)
-//! \brief Extracts the lowest 16 bits from a 64-bit integer and casts it to uint16_t.
-//! \param value The 64-bit integer from which to extract the lowest 16 bits.
-//! \return uint16_t for lowest 16 bits
+    //! \fn get_Word0_uint64(uint64_t value)
+    //! \brief Extracts the lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+    //! \param value The 64-bit integer from which to extract the lowest 16 bits.
+    //! \return uint16_t for lowest 16 bits
     static M_INLINE uint16_t get_Word0_uint64(uint64_t value)
     {
         return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x000000000000FFFF)));
     }
 
-//! \fn get_Word0_uint32(uint32_t value)
-//! \brief Extracts the lowest 16 bits from a 32-bit integer and casts it to uint16_t.
-//! \param value The 32-bit integer from which to extract the lowest 16 bits.
-//! \return uint16_t for lowest 16 bits
+    //! \fn get_Word0_uint32(uint32_t value)
+    //! \brief Extracts the lowest 16 bits from a 32-bit integer and casts it to uint16_t.
+    //! \param value The 32-bit integer from which to extract the lowest 16 bits.
+    //! \return uint16_t for lowest 16 bits
     static M_INLINE uint16_t get_Word0_uint32(uint32_t value)
     {
         return M_STATIC_CAST(uint16_t, (value & UINT32_C(0x0000FFFF)));
@@ -118,19 +118,19 @@ extern "C"
 //! \param l The 64-bit integer from which to extract the lowest 16 bits.
 #    define M_Word0(value) _Generic((value), uint32_t: get_Word0_uint32, uint64_t: get_Word0_uint64)(value)
 
-//! \fn get_Word1_uint64(uint64_t value)
-//! \brief Extracts the second lowest 16 bits from a 64-bit integer and casts it to uint16_t.
-//! \param value The 64-bit integer from which to extract the lowest 16 bits.
-//! \return uint16_t for second lowest 16 bits
+    //! \fn get_Word1_uint64(uint64_t value)
+    //! \brief Extracts the second lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+    //! \param value The 64-bit integer from which to extract the lowest 16 bits.
+    //! \return uint16_t for second lowest 16 bits
     static M_INLINE uint16_t get_Word1_uint64(uint64_t value)
     {
         return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x00000000FFFF0000)));
     }
 
-//! \fn get_Word1_uint32(uint32_t value)
-//! \brief Extracts the highest 16 bits from a 32-bit integer and casts it to uint16_t.
-//! \param value The 32-bit integer from which to extract the highest 16 bits.
-//! \return uint16_t for highest 16 bits
+    //! \fn get_Word1_uint32(uint32_t value)
+    //! \brief Extracts the highest 16 bits from a 32-bit integer and casts it to uint16_t.
+    //! \param value The 32-bit integer from which to extract the highest 16 bits.
+    //! \return uint16_t for highest 16 bits
     static M_INLINE uint16_t get_Word1_uint32(uint32_t value)
     {
         return M_STATIC_CAST(uint16_t, (value & UINT32_C(0xFFFF0000)));
@@ -143,12 +143,12 @@ extern "C"
 //! \param l The 64-bit integer from which to extract the second lowest 16 bits.
 #    define M_Word1(value) _Generic((value), uint32_t: get_Word1_uint32, uint64_t: get_Word1_uint64)(value)
 
-//! \fn get_Word2_uint64(uint64_t value)
-//! \brief Extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
-//!
-//! This macro extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
-//! \param value The 64-bit integer from which to extract the second highest 16 bits.
-//! \return uint16_t for second highest 16 bits
+    //! \fn get_Word2_uint64(uint64_t value)
+    //! \brief Extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
+    //!
+    //! This macro extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
+    //! \param value The 64-bit integer from which to extract the second highest 16 bits.
+    //! \return uint16_t for second highest 16 bits
     static M_INLINE uint16_t get_Word2_uint64(uint64_t value)
     {
         return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x0000FFFF00000000)));
@@ -161,12 +161,12 @@ extern "C"
 //! \param l The 64-bit integer from which to extract the second highest 16 bits.
 #    define M_Word2(value) _Generic((value), uint64_t: get_Word2_uint64)(value)
 
-//! \fn get_Word3_uint64(uint64_t value)
-//! \brief Extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
-//!
-//! This macro extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
-//! \param value The 64-bit integer from which to extract the highest 16 bits.
-//! \return uint16_t of the highest 16 bits.
+    //! \fn get_Word3_uint64(uint64_t value)
+    //! \brief Extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
+    //!
+    //! This macro extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
+    //! \param value The 64-bit integer from which to extract the highest 16 bits.
+    //! \return uint16_t of the highest 16 bits.
     static M_INLINE uint16_t get_Word3_uint64(uint64_t value)
     {
         return M_STATIC_CAST(uint16_t, (value & UINT64_C(0xFFFF000000000000)));

--- a/include/bit_manip.h
+++ b/include/bit_manip.h
@@ -92,33 +92,122 @@ extern "C"
 //! \param l The 64-bit integer from which to extract the upper 32 bits.
 #define M_DoubleWordInt1(l) (M_STATIC_CAST(int32_t, (((l) & UINT64_C(0xFFFFFFFF00000000)) >> 32)))
 
+#if defined(HAVE_C11_GENERIC_SELECTION)
+//! \fn get_Word0_uint64(uint64_t value)
+//! \brief Extracts the lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param value The 64-bit integer from which to extract the lowest 16 bits.
+//! \return uint16_t for lowest 16 bits
+    static M_INLINE uint16_t get_Word0_uint64(uint64_t value)
+    {
+        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x000000000000FFFF)));
+    }
+
+//! \fn get_Word0_uint32(uint32_t value)
+//! \brief Extracts the lowest 16 bits from a 32-bit integer and casts it to uint16_t.
+//! \param value The 32-bit integer from which to extract the lowest 16 bits.
+//! \return uint16_t for lowest 16 bits
+    static M_INLINE uint16_t get_Word0_uint32(uint32_t value)
+    {
+        return M_STATIC_CAST(uint16_t, (value & UINT32_C(0x0000FFFF)));
+    }
+
 //! \def M_Word0
 //! \brief Extracts the lowest 16 bits from a 64-bit integer and casts it to uint16_t.
 //!
 //! This macro extracts the lowest 16 bits from a 64-bit integer and casts it to uint16_t.
 //! \param l The 64-bit integer from which to extract the lowest 16 bits.
-#define M_Word0(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0x000000000000FFFF)) >> 0)))
+#    define M_Word0(value) _Generic((value), uint32_t: get_Word0_uint32, uint64_t: get_Word0_uint64)(value)
+
+//! \fn get_Word1_uint64(uint64_t value)
+//! \brief Extracts the second lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param value The 64-bit integer from which to extract the lowest 16 bits.
+//! \return uint16_t for second lowest 16 bits
+    static M_INLINE uint16_t get_Word1_uint64(uint64_t value)
+    {
+        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x00000000FFFF0000)));
+    }
+
+//! \fn get_Word1_uint32(uint32_t value)
+//! \brief Extracts the highest 16 bits from a 32-bit integer and casts it to uint16_t.
+//! \param value The 32-bit integer from which to extract the highest 16 bits.
+//! \return uint16_t for highest 16 bits
+    static M_INLINE uint16_t get_Word1_uint32(uint32_t value)
+    {
+        return M_STATIC_CAST(uint16_t, (value & UINT32_C(0xFFFF0000)));
+    }
 
 //! \def M_Word1
 //! \brief Extracts the second lowest 16 bits from a 64-bit integer and casts it to uint16_t.
 //!
 //! This macro extracts the second lowest 16 bits from a 64-bit integer and casts it to uint16_t.
 //! \param l The 64-bit integer from which to extract the second lowest 16 bits.
-#define M_Word1(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0x00000000FFFF0000)) >> 16)))
+#    define M_Word1(value) _Generic((value), uint32_t: get_Word1_uint32, uint64_t: get_Word1_uint64)(value)
+
+//! \fn get_Word2_uint64(uint64_t value)
+//! \brief Extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//!
+//! This macro extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param value The 64-bit integer from which to extract the second highest 16 bits.
+//! \return uint16_t for second highest 16 bits
+    static M_INLINE uint16_t get_Word2_uint64(uint64_t value)
+    {
+        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x0000FFFF00000000)));
+    }
 
 //! \def M_Word2
 //! \brief Extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
 //!
 //! This macro extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
 //! \param l The 64-bit integer from which to extract the second highest 16 bits.
-#define M_Word2(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0x0000FFFF00000000)) >> 32)))
+#    define M_Word2(value) _Generic((value), uint64_t: get_Word2_uint64)(value)
+
+//! \fn get_Word3_uint64(uint64_t value)
+//! \brief Extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//!
+//! This macro extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param value The 64-bit integer from which to extract the highest 16 bits.
+//! \return uint16_t of the highest 16 bits.
+    static M_INLINE uint16_t get_Word3_uint64(uint64_t value)
+    {
+        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0xFFFF000000000000)));
+    }
 
 //! \def M_Word3
 //! \brief Extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
 //!
 //! This macro extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
 //! \param l The 64-bit integer from which to extract the highest 16 bits.
-#define M_Word3(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0xFFFF000000000000)) >> 48)))
+#    define M_Word3(value) _Generic((value), uint64_t: get_Word3_uint64)(value)
+
+#else
+//! \def M_Word0
+//! \brief Extracts the lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+//!
+//! This macro extracts the lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param l The 64-bit integer from which to extract the lowest 16 bits.
+#    define M_Word0(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0x000000000000FFFF)) >> 0)))
+
+//! \def M_Word1
+//! \brief Extracts the second lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+//!
+//! This macro extracts the second lowest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param l The 64-bit integer from which to extract the second lowest 16 bits.
+#    define M_Word1(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0x00000000FFFF0000)) >> 16)))
+
+//! \def M_Word2
+//! \brief Extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//!
+//! This macro extracts the second highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param l The 64-bit integer from which to extract the second highest 16 bits.
+#    define M_Word2(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0x0000FFFF00000000)) >> 32)))
+
+//! \def M_Word3
+//! \brief Extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//!
+//! This macro extracts the highest 16 bits from a 64-bit integer and casts it to uint16_t.
+//! \param l The 64-bit integer from which to extract the highest 16 bits.
+#    define M_Word3(l) (M_STATIC_CAST(uint16_t, (((l) & UINT64_C(0xFFFF000000000000)) >> 48)))
+#endif
 
 //! \def M_WordInt0
 //! \brief Extracts the lowest 16 bits from a 64-bit integer and casts it to int16_t.
@@ -619,6 +708,8 @@ extern "C"
         case sizeof(uint32_t):
         case sizeof(uint64_t):
             good = true;
+            break;
+        default:
             break;
         }
         return good;

--- a/include/impl_sort_and_search.h
+++ b/include/impl_sort_and_search.h
@@ -201,9 +201,9 @@ extern "C"
     //! - \a compare is a null pointer
     M_NONNULL_PARAM_LIST(1, 2, 5)
     M_PARAM_RO(1)
-    M_PARAM_RW(2)
+    M_PARAM_RO(2)
     void* safe_bsearch_context_impl(const void*  key,
-                                    void*        ptr,
+                                    const void*  ptr,
                                     rsize_t      count,
                                     rsize_t      size,
                                     ctxcomparefn compare,

--- a/include/io_utils.h
+++ b/include/io_utils.h
@@ -40,7 +40,7 @@ extern "C"
     //! \return true if able to read an integer number, false if the format is invalid.
     M_DEPRECATED /*use the bit width specific versions instead!*/
         M_NONNULL_PARAM_LIST(1, 2) M_PARAM_RO(1) M_NULL_TERM_STRING(1)
-            M_PARAM_WO(2) bool get_And_Validate_Integer_Input(const char* strToConvert, uint64_t* outputInteger);
+            M_PARAM_RW(2) bool get_And_Validate_Integer_Input(const char* strToConvert, uint64_t* outputInteger);
 
     //! \enum eAllowedUnitInput
     //! \brief Enum specifying which units are allowed at the end of the user's input.
@@ -78,7 +78,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Uint64(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Uint64(const char*       strToConvert,
                                                                  char**            unit,
                                                                  eAllowedUnitInput unittype,
                                                                  uint64_t*         outputInteger);
@@ -96,7 +96,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Uint32(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Uint32(const char*       strToConvert,
                                                                  char**            unit,
                                                                  eAllowedUnitInput unittype,
                                                                  uint32_t*         outputInteger);
@@ -114,7 +114,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Uint16(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Uint16(const char*       strToConvert,
                                                                  char**            unit,
                                                                  eAllowedUnitInput unittype,
                                                                  uint16_t*         outputInteger);
@@ -132,7 +132,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Uint8(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Uint8(const char*       strToConvert,
                                                                 char**            unit,
                                                                 eAllowedUnitInput unittype,
                                                                 uint8_t*          outputInteger);
@@ -150,7 +150,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Int64(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Int64(const char*       strToConvert,
                                                                 char**            unit,
                                                                 eAllowedUnitInput unittype,
                                                                 int64_t*          outputInteger);
@@ -168,7 +168,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Int32(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Int32(const char*       strToConvert,
                                                                 char**            unit,
                                                                 eAllowedUnitInput unittype,
                                                                 int32_t*          outputInteger);
@@ -186,7 +186,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Int16(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Int16(const char*       strToConvert,
                                                                 char**            unit,
                                                                 eAllowedUnitInput unittype,
                                                                 int16_t*          outputInteger);
@@ -204,7 +204,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_Int8(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_Int8(const char*       strToConvert,
                                                                char**            unit,
                                                                eAllowedUnitInput unittype,
                                                                int8_t*           outputInteger);
@@ -222,7 +222,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_ULL(const char*         strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_ULL(const char*         strToConvert,
                                                               char**              unit,
                                                               eAllowedUnitInput   unittype,
                                                               unsigned long long* outputInteger);
@@ -240,7 +240,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_UL(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_UL(const char*       strToConvert,
                                                              char**            unit,
                                                              eAllowedUnitInput unittype,
                                                              unsigned long*    outputInteger);
@@ -258,7 +258,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_UI(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_UI(const char*       strToConvert,
                                                              char**            unit,
                                                              eAllowedUnitInput unittype,
                                                              unsigned int*     outputInteger);
@@ -276,7 +276,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_US(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_US(const char*       strToConvert,
                                                              char**            unit,
                                                              eAllowedUnitInput unittype,
                                                              unsigned short*   outputInteger);
@@ -294,7 +294,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_UC(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_UC(const char*       strToConvert,
                                                              char**            unit,
                                                              eAllowedUnitInput unittype,
                                                              unsigned char*    outputInteger);
@@ -312,7 +312,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_LL(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_LL(const char*       strToConvert,
                                                              char**            unit,
                                                              eAllowedUnitInput unittype,
                                                              long long*        outputInteger);
@@ -330,7 +330,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_L(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_L(const char*       strToConvert,
                                                             char**            unit,
                                                             eAllowedUnitInput unittype,
                                                             long*             outputInteger);
@@ -348,7 +348,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_I(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_I(const char*       strToConvert,
                                                             char**            unit,
                                                             eAllowedUnitInput unittype,
                                                             int*              outputInteger);
@@ -366,7 +366,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_S(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_S(const char*       strToConvert,
                                                             char**            unit,
                                                             eAllowedUnitInput unittype,
                                                             short*            outputInteger);
@@ -384,7 +384,7 @@ extern "C"
     //! \param[out] outputInteger Pointer to the integer to store the output.
     //! \return true if able to read an integer number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Integer_Input_C(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Integer_Input_C(const char*       strToConvert,
                                                             char**            unit,
                                                             eAllowedUnitInput unittype,
                                                             char*             outputInteger);
@@ -402,7 +402,7 @@ extern "C"
     //! \param[out] outputFloat Pointer to the float to store the output.
     //! \return true if able to read a float number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Float_Input(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Float_Input(const char*       strToConvert,
                                                         char**            unit,
                                                         eAllowedUnitInput unittype,
                                                         float*            outputFloat);
@@ -420,7 +420,7 @@ extern "C"
     //! \param[out] outputFloat Pointer to the double to store the output.
     //! \return true if able to read a double number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_Double_Input(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_Double_Input(const char*       strToConvert,
                                                          char**            unit,
                                                          eAllowedUnitInput unittype,
                                                          double*           outputFloat);
@@ -438,7 +438,7 @@ extern "C"
     //! \param[out] outputFloat Pointer to the long double to store the output.
     //! \return true if able to read a long double number, false if the format is invalid.
     M_NODISCARD M_NONNULL_PARAM_LIST(1, 4) M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_WO(2)
-        M_PARAM_WO(4) bool get_And_Validate_LDouble_Input(const char*       strToConvert,
+        M_PARAM_RW(4) bool get_And_Validate_LDouble_Input(const char*       strToConvert,
                                                           char**            unit,
                                                           eAllowedUnitInput unittype,
                                                           long double*      outputFloat);
@@ -992,13 +992,16 @@ extern "C"
         safe_gets_impl(streamptr, n, __FILE__, __func__, __LINE__, "safe_gets(" #streamptr ", " #n ")")
 #endif
 
-// These are for specifying the base for conversion in strto(u)l(l) functions
-#define BASE_0_AUTO     (0)
-#define BASE_2_BINARY   (2)
-#define BASE_8_OCTAL    (8)
-#define BASE_10_DECIMAL (10)
-#define BASE_16_HEX     (16)
-#define BASE_36_MAX     (36) // this is the max base required by the standards for strtol type functions
+    // These are for specifying the base for conversion in strto(u)l(l) functions
+    enum eBaseStrToInt
+    {
+        BASE_0_AUTO     = 0,
+        BASE_2_BINARY   = 2,
+        BASE_8_OCTAL    = 8,
+        BASE_10_DECIMAL = 10,
+        BASE_16_HEX     = 16,
+        BASE_36_MAX     = 36 // this is the max base required by the standards for strtol type functions
+    };
 
 // These safe string to long conversion functions check for NULL ptr on str and value.
 // They properly check errno for range errors, and detect invalid conversions too

--- a/include/memory_safety.h
+++ b/include/memory_safety.h
@@ -1517,7 +1517,7 @@ extern "C"
 //! \warning Do not use on heap allocated memory!
 //! \param[in] array stack array to determine the size of.
 //! \return number of bytes allocated on the stack for the array
-#define SIZE_OF_STACK_ARRAY(array) (sizeof(array) / sizeof((*array)))
+#define SIZE_OF_STACK_ARRAY(array) (sizeof(array) / sizeof((*(array))))
 
 #if defined(__cplusplus)
 }

--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,7 @@ if c.get_id().contains('gcc') or c.get_id().contains('clang')
   '-Wint-to-pointer-cast',
   '-Wimplicit-fallthrough',
   '-D_GLIBCXX_ASSERTIONS',
-  '-fstrict-flex-arrays=1', #NOTE: Using level 1 since Windows often uses [1] at the end of it's structures. opensea-*libs has used this in a few places too.
+  '-fstrict-flex-arrays=3',
   '-fno-delete-null-pointer-checks',
   '-fno-strict-overflow',
   '-fno-strict-aliasing',

--- a/src/bit_manip.c
+++ b/src/bit_manip.c
@@ -15,6 +15,7 @@
 #include "predef_env_detect.h"
 #include "type_conversion.h"
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 //! \fn static M_INLINE size_t get_Bytes_Abs_Range(size_t msb, size_t lsb)
@@ -105,6 +106,15 @@ bool get_Bytes_To_16(const uint8_t* dataPtrBeginning, size_t fullDataLen, size_t
     }
 }
 
+enum eGenericIntMaxBits
+{
+    GENERIC_INT_8BIT_MAX = 7,
+    GENERIC_INT_16BIT_MAX = 15,
+    GENERIC_INT_32BIT_MAX = 31,
+    GENERIC_INT_64BIT_MAX = 63,
+    GENERIC_INT_MAX_BIT = 63
+};
+
 //! \fn static M_INLINE genericint_t gen_8bit_range(genericint_t         input,
 //!                                            M_ATTR_UNUSED size_t outputsize,
 //!                                            uint8_t              msb,
@@ -123,7 +133,7 @@ static M_INLINE genericint_t gen_8bit_range(genericint_t         input,
 {
     genericint_t out;
     safe_memset(&out, sizeof(genericint_t), 0, sizeof(genericint_t));
-    if (msb > 7 || lsb > 7)
+    if (msb > GENERIC_INT_8BIT_MAX || lsb > GENERIC_INT_8BIT_MAX)
     {
         errno = ERANGE;
     }
@@ -153,7 +163,7 @@ static M_INLINE genericint_t gen_16bit_range(genericint_t input, size_t outputsi
 {
     genericint_t out;
     safe_memset(&out, sizeof(genericint_t), 0, sizeof(genericint_t));
-    if (msb > 15 || lsb > 15)
+    if (msb > GENERIC_INT_16BIT_MAX || lsb > GENERIC_INT_16BIT_MAX)
     {
         errno = ERANGE;
     }
@@ -199,7 +209,7 @@ static M_INLINE genericint_t gen_32bit_range(genericint_t input, size_t outputsi
 {
     genericint_t out;
     safe_memset(&out, sizeof(genericint_t), 0, sizeof(genericint_t));
-    if (msb > 31 || lsb > 31)
+    if (msb > GENERIC_INT_32BIT_MAX || lsb > GENERIC_INT_32BIT_MAX)
     {
         errno = ERANGE;
     }
@@ -248,6 +258,8 @@ static M_INLINE genericint_t gen_32bit_range(genericint_t input, size_t outputsi
     return out;
 }
 
+
+
 //! \fn genericint_t gen_64bit_range(genericint_t input, size_t outputsize, uint8_t msb, uint8_t lsb)
 //! \brief internal function to get bit range in a qword (uint64_t)
 //!
@@ -260,7 +272,7 @@ static M_INLINE genericint_t gen_64bit_range(genericint_t input, size_t outputsi
 {
     genericint_t out;
     safe_memset(&out, sizeof(genericint_t), 0, sizeof(genericint_t));
-    if (msb > 63 || lsb > 63)
+    if (msb > GENERIC_INT_64BIT_MAX || lsb > GENERIC_INT_64BIT_MAX)
     {
         errno = ERANGE;
     }
@@ -330,7 +342,7 @@ genericint_t generic_Get_Bit_Range(genericint_t input, size_t outputsize, uint8_
     {
         errno = EINVAL;
     }
-    else if (msb > 63 || lsb > 63)
+    else if (msb > GENERIC_INT_MAX_BIT || lsb > GENERIC_INT_MAX_BIT)
     {
         errno = ERANGE;
     }
@@ -349,6 +361,9 @@ genericint_t generic_Get_Bit_Range(genericint_t input, size_t outputsize, uint8_
             break;
         case sizeof(uint64_t):
             out = gen_64bit_range(input, outputsize, msb, lsb);
+            break;
+        default:
+            perror("Error in generic get bit range function");
             break;
         }
     }

--- a/src/bit_manip.c
+++ b/src/bit_manip.c
@@ -108,11 +108,11 @@ bool get_Bytes_To_16(const uint8_t* dataPtrBeginning, size_t fullDataLen, size_t
 
 enum eGenericIntMaxBits
 {
-    GENERIC_INT_8BIT_MAX = 7,
+    GENERIC_INT_8BIT_MAX  = 7,
     GENERIC_INT_16BIT_MAX = 15,
     GENERIC_INT_32BIT_MAX = 31,
     GENERIC_INT_64BIT_MAX = 63,
-    GENERIC_INT_MAX_BIT = 63
+    GENERIC_INT_MAX_BIT   = 63
 };
 
 //! \fn static M_INLINE genericint_t gen_8bit_range(genericint_t         input,
@@ -257,8 +257,6 @@ static M_INLINE genericint_t gen_32bit_range(genericint_t input, size_t outputsi
     }
     return out;
 }
-
-
 
 //! \fn genericint_t gen_64bit_range(genericint_t input, size_t outputsize, uint8_t msb, uint8_t lsb)
 //! \brief internal function to get bit range in a qword (uint64_t)

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -1454,7 +1454,8 @@ M_NODISCARD bool get_And_Validate_Integer_Input_ULL(const char*         strToCon
         // If everything is a valid hex digit.
         if (strType != INT_INPUT_INVALID)
         {
-            if (0 != safe_strtoull(outputInteger, strToConvert, unit, strType) || (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
+            if (0 != safe_strtoull(outputInteger, strToConvert, unit, strType) ||
+                (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
             {
                 result = false;
             }
@@ -1485,7 +1486,8 @@ M_NODISCARD bool get_And_Validate_Integer_Input_UL(const char*       strToConver
         // If everything is a valid hex digit.
         if (strType != INT_INPUT_INVALID)
         {
-            if (0 != safe_strtoul(outputInteger, strToConvert, unit, strType) || (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
+            if (0 != safe_strtoul(outputInteger, strToConvert, unit, strType) ||
+                (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
             {
                 result = false;
             }
@@ -1591,7 +1593,8 @@ M_NODISCARD bool get_And_Validate_Integer_Input_LL(const char*       strToConver
         // If everything is a valid hex digit.
         if (strType != INT_INPUT_INVALID)
         {
-            if (0 != safe_strtoll(outputInteger, strToConvert, unit, strType) || (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
+            if (0 != safe_strtoll(outputInteger, strToConvert, unit, strType) ||
+                (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
             {
                 result = false;
             }
@@ -1622,7 +1625,8 @@ M_NODISCARD bool get_And_Validate_Integer_Input_L(const char*       strToConvert
         // If everything is a valid hex digit.
         if (strType != INT_INPUT_INVALID)
         {
-            if (0 != safe_strtol(outputInteger, strToConvert, unit, strType) || (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
+            if (0 != safe_strtol(outputInteger, strToConvert, unit, strType) ||
+                (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
             {
                 result = false;
             }
@@ -1781,7 +1785,9 @@ M_NODISCARD bool get_And_Validate_Float_Input(const char*       strToConvert,
     DISABLE_NONNULL_COMPARE
     if (strToConvert != M_NULLPTR && outputFloat != M_NULLPTR)
     {
-        if (0 != safe_strtof(outputFloat, strToConvert, unit) || (unit && !is_Allowed_Unit_For_Get_And_Validate_Input(*unit, unittype)) || (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
+        if (0 != safe_strtof(outputFloat, strToConvert, unit) ||
+            (unit && !is_Allowed_Unit_For_Get_And_Validate_Input(*unit, unittype)) ||
+            (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
         {
             result = false;
         }
@@ -1803,7 +1809,9 @@ M_NODISCARD bool get_And_Validate_Double_Input(const char*       strToConvert,
     DISABLE_NONNULL_COMPARE
     if (strToConvert != M_NULLPTR && outputFloat != M_NULLPTR)
     {
-        if (0 != safe_strtod(outputFloat, strToConvert, unit) || (unit && !is_Allowed_Unit_For_Get_And_Validate_Input(*unit, unittype)) || (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
+        if (0 != safe_strtod(outputFloat, strToConvert, unit) ||
+            (unit && !is_Allowed_Unit_For_Get_And_Validate_Input(*unit, unittype)) ||
+            (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
         {
             result = false;
         }
@@ -1825,7 +1833,9 @@ M_NODISCARD bool get_And_Validate_LDouble_Input(const char*       strToConvert,
     DISABLE_NONNULL_COMPARE
     if (strToConvert != M_NULLPTR && outputFloat != M_NULLPTR)
     {
-        if (0 != safe_strtold(outputFloat, strToConvert, unit) || (unit && !is_Allowed_Unit_For_Get_And_Validate_Input(*unit, unittype)) || (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
+        if (0 != safe_strtold(outputFloat, strToConvert, unit) ||
+            (unit && !is_Allowed_Unit_For_Get_And_Validate_Input(*unit, unittype)) ||
+            (unit == M_NULLPTR && unittype != ALLOW_UNIT_NONE))
         {
             result = false;
         }

--- a/src/memory_safety.c
+++ b/src/memory_safety.c
@@ -434,8 +434,8 @@ errno_t safe_memset_impl(void*       dest,
             return error;
         }
 #if defined(HAVE_MEMSET_EXPLICIT)
-        memset_explicit(dest, ch,
-                        count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+        memset_explicit(dest, ch, // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+                        count);   // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #elif IS_NETBSD_VERSION(7, 0, 0) || defined(HAVE_EXPLICIT_MEMSET)
         // https://man.netbsd.org/NetBSD-8.0/explicit_memset.3
         // https://docs.oracle.com/cd/E88353_01/html/E37843/explicit-memset-3c.html
@@ -450,16 +450,16 @@ errno_t safe_memset_impl(void*       dest,
         // last attempts to prevent optimization as best we can
 #    if IS_GCC_VERSION(3, 0) || IS_CLANG_VERSION(1, 0)
 #        if defined(HAVE_BUILTIN_MEMSET)
-        __builtin_memset(dest, ch,
-                         count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+        __builtin_memset(dest, ch, // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+                         count);   // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #        else
         memset(dest, ch, count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #        endif
         asm volatile("" ::: "memory");
 #    elif defined(HAS_BUILT_IN_CLEAR_CACHE)
 #        if defined(HAVE_BUILTIN_MEMSET)
-        __builtin_memset(dest, ch,
-                         count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+        __builtin_memset(dest, ch, // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+                         count);   // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #        else
         memset(dest, ch, count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #        endif
@@ -470,8 +470,8 @@ errno_t safe_memset_impl(void*       dest,
              (defined(WIN_API_TARGET_VERSION) && WIN_API_TARGET_VERSION >= WIN_API_TARGET_WIN11_26100))
         // SecureZeroMemory2 calls FillVolatileMemory which we can use here to
         // do the same thing
-        FillVolatileMemory(dest, count,
-                           ch); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+        FillVolatileMemory(dest, count, // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+                           ch);         // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #        elif defined(_M_AMD64) || (!defined(_M_CEE) && defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC))
         // NOTE: Using the securezeromemory implementation in this case
         volatile char* vptr = M_REINTERPRET_CAST(volatile char*, dest);
@@ -928,8 +928,8 @@ errno_t safe_memmove_impl(void*       dest,
             // from Microsoft's compiler.
             memmove_s(dest, destsz, src, count);
 #elif defined(HAVE_BUILTIN_MEMMOVE)
-            __builtin_memmove(dest, src,
-                              count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+            __builtin_memmove(dest, src, // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+                              count);    // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #else
             memmove(dest, src, count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #endif // HAVE_MSFT_SECURE_LIB
@@ -1016,8 +1016,8 @@ errno_t safe_memcpy_impl(void* M_RESTRICT       dest,
             // from Microsoft's compiler.
             memcpy_s(dest, destsz, src, count);
 #elif defined(HAVE_BUILTIN_MEMCPY)
-            __builtin_memcpy(dest, src,
-                             count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+            __builtin_memcpy(dest, src, // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+                             count);    // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #else
             memcpy(dest, src, count); // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 #endif // HAVE_MSFT_SECURE_LIB

--- a/src/safe_bsearch.c
+++ b/src/safe_bsearch.c
@@ -81,7 +81,7 @@
  */
 
 void* safe_bsearch_context_impl(const void*  key,
-                                void*        ptr,
+                                const void*  ptr,
                                 rsize_t      count,
                                 rsize_t      size,
                                 ctxcomparefn compare,

--- a/src/safe_lsearch.c
+++ b/src/safe_lsearch.c
@@ -38,15 +38,18 @@
  * unchanged, you can do what ever you want with this file.
  */
 
-#define LWORK_MODE_SEARCH 1
-#define LWORK_MODE_FIND   0
+typedef enum eLworkModeEnum
+{
+    LWORK_MODE_SEARCH = 1,
+    LWORK_MODE_FIND   = 0
+} eLworkMode;
 
 static void* safe_lwork(const void* key,
                         const void* base,
                         size_t*     nelp,
                         size_t      width,
                         comparefn   compar,
-                        int         addelem,
+                        eLworkMode  addelem,
                         const char* file,
                         const char* function,
                         int         line,
@@ -83,7 +86,7 @@ static void* safe_lwork(const void* key,
                         size_t*     nelp,
                         size_t      width,
                         comparefn   compar,
-                        int         addelem,
+                        eLworkMode  addelem,
                         const char* file,
                         const char* function,
                         int         line,
@@ -229,7 +232,7 @@ static void* safe_lwork_context(const void*  key,
                                 size_t       width,
                                 ctxcomparefn compar,
                                 void*        context,
-                                int          addelem,
+                                eLworkMode   addelem,
                                 const char*  file,
                                 const char*  function,
                                 int          line,
@@ -271,7 +274,7 @@ static void* safe_lwork_context(const void*  key,
                                 size_t       width,
                                 ctxcomparefn compar,
                                 void*        context,
-                                int          addelem,
+                                eLworkMode   addelem,
                                 const char*  file,
                                 const char*  function,
                                 int          line,

--- a/src/safe_strtok.c
+++ b/src/safe_strtok.c
@@ -176,9 +176,9 @@ char* safe_strtok_impl(char* M_RESTRICT       str,
     while (*strmax > RSIZE_T_C(0))
     {
         bool breakdelimloop = false;
-        c                   = *str++;
+        c                   = C_CAST(unsigned char, *str++);
         *strmax -= RSIZE_T_C(1); // Seagate modification
-        for (spanp = M_CONST_CAST(char*, delim); (sc = *spanp++) != 0 && !breakdelimloop;)
+        for (spanp = M_CONST_CAST(char*, delim); (sc = C_CAST(unsigned char, *spanp++)) != 0 && !breakdelimloop;)
         {
             if (c == sc)
             {
@@ -227,12 +227,12 @@ char* safe_strtok_impl(char* M_RESTRICT       str,
     // Seagate modification: Added staying within bounds of memory with strmax > 0
     for (; *strmax > RSIZE_T_C(0);)
     {
-        c = *str++;
+        c = C_CAST(unsigned char, *str++);
         *strmax -= RSIZE_T_C(1); // Seagate modification
         spanp = M_CONST_CAST(char*, delim);
         do
         {
-            if ((sc = *spanp++) == c)
+            if ((sc = C_CAST(unsigned char, *spanp++)) == c)
             {
                 if (c == 0)
                 {

--- a/src/secure_file.c
+++ b/src/secure_file.c
@@ -118,7 +118,7 @@ void free_Secure_File_Info(secureFileInfo** fileInfo)
             }
             if ((*fileInfo)->errorString != M_NULLPTR)
             {
-                explicit_zeroes(M_CONST_CAST(void**, (*fileInfo)->errorString), safe_strlen((*fileInfo)->errorString));
+                explicit_zeroes(M_CONST_CAST(void*, (*fileInfo)->errorString), safe_strlen((*fileInfo)->errorString));
                 safe_free_core(M_CONST_CAST(void**, &(*fileInfo)->errorString));
             }
             explicit_zeroes(*fileInfo, sizeof(secureFileInfo));

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -355,14 +355,14 @@ struct tm* milliseconds_Since_Unix_Epoch_To_Struct_TM(uint64_t milliseconds, str
             {
                 daysInMonth += 1;
             }
-            if (remsec < (secPerDay * daysInMonth))
+            if (remsec < (M_STATIC_CAST(int64_t, secPerDay) * M_STATIC_CAST(int64_t, daysInMonth)))
             {
                 day = M_STATIC_CAST(int, (remsec / M_STATIC_CAST(int64_t, secPerDay)) + INT64_C(1)); // 1 based index
                 yday += day - 1;                                                                     // 0 based index
                 remsec %= secPerDay;
                 break;
             }
-            remsec -= secPerDay * daysInMonth;
+            remsec -= (M_STATIC_CAST(int64_t, secPerDay) * M_STATIC_CAST(int64_t, daysInMonth));
             yday += daysInMonth;
         }
 
@@ -380,7 +380,7 @@ struct tm* milliseconds_Since_Unix_Epoch_To_Struct_TM(uint64_t milliseconds, str
         time->tm_min   = minute;
         time->tm_sec   = second;
         time->tm_isdst = -1;
-        time->tm_wday  = ((seconds / secPerDay) + JAN_1_1970_DAY_OF_WEEK) % DAYS_IN_WEEK;
+        time->tm_wday  = M_STATIC_CAST(int, ((seconds / M_STATIC_CAST(int64_t, secPerDay)) + M_STATIC_CAST(int64_t, JAN_1_1970_DAY_OF_WEEK)) % M_STATIC_CAST(int64_t, DAYS_IN_WEEK));
     }
     RESTORE_NONNULL_COMPARE
     return time;

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -380,7 +380,9 @@ struct tm* milliseconds_Since_Unix_Epoch_To_Struct_TM(uint64_t milliseconds, str
         time->tm_min   = minute;
         time->tm_sec   = second;
         time->tm_isdst = -1;
-        time->tm_wday  = M_STATIC_CAST(int, ((seconds / M_STATIC_CAST(int64_t, secPerDay)) + M_STATIC_CAST(int64_t, JAN_1_1970_DAY_OF_WEEK)) % M_STATIC_CAST(int64_t, DAYS_IN_WEEK));
+        time->tm_wday  = M_STATIC_CAST(
+            int, ((seconds / M_STATIC_CAST(int64_t, secPerDay)) + M_STATIC_CAST(int64_t, JAN_1_1970_DAY_OF_WEEK)) %
+                     M_STATIC_CAST(int64_t, DAYS_IN_WEEK));
     }
     RESTORE_NONNULL_COMPARE
     return time;


### PR DESCRIPTION
This request adds some new clang-tidy checks and removes a couple new ones that are not currently compatible with C99 style code we have.
This involved adding explicit casts where clang-tidy recommended, fix a missing default case, and added enums/definitions for some magic numbers

I also added some new functions under a generic selection macro to help detect more warnings/incorrect uses of M_Word0, etc type functions at compile time when C11 generic selection is supported.

changed -fstrict-flex-arrays=1 to 3 in order to allow GCC/Clang to better detect bounds issues at compile time.

Fixed a bug on which pointer is passed to explicit_zeros in secure_file.c 