### PR TITLE
Feature/cleanup

### DIFF
--- a/include/code_attributes.h
+++ b/include/code_attributes.h
@@ -362,8 +362,6 @@ extern "C"
 #            define M_NORETURN [[noreturn]]
 #        endif
 #    endif
-#elif defined noreturn
-#    define M_NORETURN noreturn
 #elif defined __has_c_attribute
 #    if __has_c_attribute(noreturn)
 #        define M_NORETURN [[noreturn]]
@@ -372,6 +370,8 @@ extern "C"
 #    elif __has_c_attribute(___Noreturn__)
 #        define M_NORETURN [[___Noreturn__]]
 #    endif
+#elif defined noreturn
+#    define M_NORETURN noreturn
 #endif
 #if !defined M_NORETURN
 #    if defined __has_attribute

--- a/include/common_types.h
+++ b/include/common_types.h
@@ -546,6 +546,12 @@ typedef int32_t intptr_t;
 //! This macro can be used within UINTwidth_C type macros as needed.
 #define OBSOLETE 0
 
+//! \def UNUSED
+//! \brief Defines a macro for an unused field set to zero
+//!
+//! This macro can be used within UINTwidth_C type macros as needed.
+#define UNUSED 0
+
 //! \def M_NULLPTR
 //! \brief Defines a macro for nullptr to handle different standards and environments.
 //!

--- a/include/error_translation.h
+++ b/include/error_translation.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include "common_types.h"
 #include "code_attributes.h"
+#include "common_types.h"
 
 #if defined(__cplusplus)
 extern "C"
@@ -24,7 +24,7 @@ extern "C"
     //!
     //! \param[in] error The error number to translate
     //! \return M_NULLPTR if memory cannot be allocated or error cannot be translated. Pointer to string successful.
-    M_FUNC_ATTR_MALLOC char *get_strerror(errno_t error);
+    M_FUNC_ATTR_MALLOC char* get_strerror(errno_t error);
 
     //! \brief Prints the error number and its meaning to the screen.
     //!

--- a/include/error_translation.h
+++ b/include/error_translation.h
@@ -13,11 +13,18 @@
 #pragma once
 
 #include "common_types.h"
+#include "code_attributes.h"
 
 #if defined(__cplusplus)
 extern "C"
 {
 #endif
+
+    //! \brief returns an allocated buffer with translation of the errno value
+    //!
+    //! \param[in] error The error number to translate
+    //! \return M_NULLPTR if memory cannot be allocated or error cannot be translated. Pointer to string successful.
+    M_FUNC_ATTR_MALLOC char *get_strerror(errno_t error);
 
     //! \brief Prints the error number and its meaning to the screen.
     //!

--- a/include/io_utils.h
+++ b/include/io_utils.h
@@ -20,7 +20,9 @@
 #include "common_types.h"
 #include "constraint_handling.h"
 #include "env_detect.h"
+#include "error_translation.h"
 #include "impl_io_utils.h"
+#include "memory_safety.h"
 #include "type_conversion.h"
 #include <stdarg.h>
 #include <stdio.h>
@@ -1627,6 +1629,27 @@ extern "C"
 #    define safe_atof(value, str)                                                                                      \
         safe_atof_impl(value, str, __FILE__, __func__, __LINE__, "safe_atof(" #value ", " #str ")")
 #endif
+
+    //! \fn errno_t checked_fputs(const char* nofmt, FILE* out)
+    //! \brief calls fputs and checks for EOF on error. Will output an error to stderr
+    //!        if the error can be translated successfully.
+    //! \param[in] nofmt the string to write. This cannot include any formatting (ex: %s).
+    //!                  If formatting is required, fprintf should be used instead.
+    //! \param[in] out the file pointer to write the string to.  Newlines, tabs, etc are allowed.
+    //! \return returns 0 on success and errno otherwise. EINVAL if either parameter is null.
+    M_NONNULL_PARAM_LIST(1, 2)
+    M_NULL_TERM_STRING(1) M_PARAM_RO(1) M_PARAM_RW(2) errno_t checked_fputs(const char* nofmt, FILE* out);
+
+    //! \fn errno_t print_str(const char* nofmt)
+    //! \brief similar to puts, but does not write a newline automatically.
+    //!        Calls checked_fputs with second argument set to stdout
+    //! \param[in] nofmt The string to write. Does not include any formatting (ex: %s) as it will be ignored.
+    //!                  Use printf for formatted strings. Newlines, tabs, etc are allowed.
+    //! \return returns 0 on success and errno otherwise.
+    M_NONNULL_PARAM_LIST(1) M_NULL_TERM_STRING(1) M_PARAM_RO(1) static M_INLINE errno_t print_str(const char* nofmt)
+    {
+        return checked_fputs(nofmt, stdout);
+    }
 
 #if defined(__cplusplus)
 }

--- a/include/secure_file.h
+++ b/include/secure_file.h
@@ -472,6 +472,21 @@ extern "C"
         bool caseInsensitive;
     } fileExt;
 
+    //! \def FILE_EXT_LIST_END
+    //! \brief Helper macro to easily insert the end of the file extension list.
+    #define FILE_EXT_LIST_END { M_NULLPTR, false }
+
+    //! \def FILE_EXT_LIST_DECL
+    //! \brief Helper macro to create a list of file extensions for secure file. Automatically appends
+    //! FILE_EXT_LIST_END for the user to make sure the list always terminates correctly
+    //! \code
+    //! list[] = FILE_EXT_LIST_DECL({".bin", false});
+    //! \endcode
+    //! \code
+    //! list[] = FILE_EXT_LIST_DECL({".bin", false}, {".json", true});
+    //! \endcode
+    #define FILE_EXT_LIST_DECL(...) {__VA_ARGS__, FILE_EXT_LIST_END}
+
     //! \fn M_NODISCARD secureFileInfo* secure_Open_File(const char* filename,
     //!                                                  const char* mode,
     //!                                                  const fileExt* extList /*optional*/,

--- a/include/secure_file.h
+++ b/include/secure_file.h
@@ -472,6 +472,8 @@ extern "C"
         bool caseInsensitive;
     } fileExt;
 
+    // clang-format off
+    
     //! \def FILE_EXT_LIST_END
     //! \brief Helper macro to easily insert the end of the file extension list.
     #define FILE_EXT_LIST_END { M_NULLPTR, false }
@@ -486,6 +488,8 @@ extern "C"
     //! list[] = FILE_EXT_LIST_DECL({".bin", false}, {".json", true});
     //! \endcode
     #define FILE_EXT_LIST_DECL(...) {__VA_ARGS__, FILE_EXT_LIST_END}
+
+    // clang-format on
 
     //! \fn M_NODISCARD secureFileInfo* secure_Open_File(const char* filename,
     //!                                                  const char* mode,

--- a/src/env_detect.c
+++ b/src/env_detect.c
@@ -23,41 +23,41 @@ void print_Architecture(eArchitecture arch)
     switch (arch)
     {
     case OPENSEA_ARCH_X86:
-        printf("X86");
+        print_str("X86");
         break;
     case OPENSEA_ARCH_X86_64:
-        printf("X86_64");
+        print_str("X86_64");
         break;
     case OPENSEA_ARCH_ARM:
-        printf("ARM");
+        print_str("ARM");
         break;
     case OPENSEA_ARCH_ARM64:
-        printf("ARM64");
+        print_str("ARM64");
         break;
     case OPENSEA_ARCH_POWERPC:
-        printf("PPC");
+        print_str("PPC");
         break;
     case OPENSEA_ARCH_POWERPC64:
-        printf("PPC64");
+        print_str("PPC64");
         break;
     case OPENSEA_ARCH_IA_64:
-        printf("IA64");
+        print_str("IA64");
         break;
     case OPENSEA_ARCH_SPARC:
-        printf("SPARC");
+        print_str("SPARC");
         break;
     case OPENSEA_ARCH_ALPHA:
-        printf("Alpha");
+        print_str("Alpha");
         break;
     case OPENSEA_ARCH_SYSTEMZ:
-        printf("SystemZ");
+        print_str("SystemZ");
         break;
     case OPENSEA_ARCH_MIPS:
-        printf("MIPS");
+        print_str("MIPS");
         break;
     case OPENSEA_ARCH_UNKNOWN:
     case OPENSEA_ARCH_RESERVED:
-        printf("Unknown Architecture");
+        print_str("Unknown Architecture");
         break;
     }
 }
@@ -69,51 +69,51 @@ void print_Endianness(eEndianness endian, bool shortPrint)
     case OPENSEA_LITTLE_ENDIAN:
         if (shortPrint)
         {
-            printf("LSB");
+            print_str("LSB");
         }
         else
         {
-            printf("Little Endian");
+            print_str("Little Endian");
         }
         break;
     case OPENSEA_BIG_ENDIAN:
         if (shortPrint)
         {
-            printf("MSB");
+            print_str("MSB");
         }
         else
         {
-            printf("Big Endian");
+            print_str("Big Endian");
         }
         break;
     case OPENSEA_LITTLE_WORD_ENDIAN:
         if (shortPrint)
         {
-            printf("LSW");
+            print_str("LSW");
         }
         else
         {
-            printf("Little Endian (Word)");
+            print_str("Little Endian (Word)");
         }
         break;
     case OPENSEA_BIG_WORD_ENDIAN:
         if (shortPrint)
         {
-            printf("MSW");
+            print_str("MSW");
         }
         else
         {
-            printf("Big Endian (Word)");
+            print_str("Big Endian (Word)");
         }
         break;
     case OPENSEA_UNKNOWN_ENDIAN:
         if (shortPrint)
         {
-            printf("???");
+            print_str("???");
         }
         else
         {
-            printf("Unknown Endianness");
+            print_str("Unknown Endianness");
         }
         break;
     }
@@ -124,47 +124,47 @@ void print_OS_Type(eOSType osType)
     switch (osType)
     {
     case OS_WINDOWS:
-        printf("Windows");
+        print_str("Windows");
         break;
     case OS_LINUX:
-        printf("Linux");
+        print_str("Linux");
         break;
     case OS_FREEBSD:
-        printf("FreeBSD");
+        print_str("FreeBSD");
         break;
     case OS_SOLARIS:
-        printf("Solaris");
+        print_str("Solaris");
         break;
     case OS_MACOSX:
-        printf("Mac OSX");
+        print_str("Mac OSX");
         break;
     case OS_AIX:
-        printf("AIX");
+        print_str("AIX");
         break;
     case OS_TRU64:
-        printf("TRU64");
+        print_str("TRU64");
         break;
     case OS_OPENBSD:
-        printf("OpenBSD");
+        print_str("OpenBSD");
         break;
     case OS_NETBSD:
-        printf("NetBSD");
+        print_str("NetBSD");
         break;
     case OS_DRAGONFLYBSD:
-        printf("Dragonfly BSD");
+        print_str("Dragonfly BSD");
         break;
     case OS_HPUX:
-        printf("HP UX");
+        print_str("HP UX");
         break;
     case OS_ESX:
-        printf("VMWare ESXi");
+        print_str("VMWare ESXi");
         break;
     case OS_UEFI:
-        printf("UEFI");
+        print_str("UEFI");
         break;
     case OS_UNKNOWN:
     default:
-        printf("Unknown OS");
+        print_str("Unknown OS");
         break;
     }
 }
@@ -240,7 +240,7 @@ void print_OS_Version(ptrOSVersionNumber versionNumber)
         break;
     case OS_UNKNOWN:
     default:
-        printf("Unknown OS Version");
+        print_str("Unknown OS Version");
         break;
     }
 }
@@ -473,35 +473,35 @@ void print_Compiler(eCompiler compilerUsed)
     switch (compilerUsed)
     {
     case OPENSEA_COMPILER_MICROSOFT_VISUAL_C_CPP:
-        printf("Microsoft Visual C/C++");
+        print_str("Microsoft Visual C/C++");
         break;
     case OPENSEA_COMPILER_GCC:
-        printf("GCC");
+        print_str("GCC");
         break;
     case OPENSEA_COMPILER_CLANG:
-        printf("Clang");
+        print_str("Clang");
         break;
     case OPENSEA_COMPILER_MINGW:
-        printf("MinGW");
+        print_str("MinGW");
         break;
     case OPENSEA_COMPILER_INTEL_C_CPP:
-        printf("Intel C/C++");
+        print_str("Intel C/C++");
         break;
     case OPENSEA_COMPILER_SUNPRO_C_CPP:
-        printf("Oracle Sunpro C/C++");
+        print_str("Oracle Sunpro C/C++");
         break;
     case OPENSEA_COMPILER_IBM_XL_C_CPP:
-        printf("IBM XL C/C++");
+        print_str("IBM XL C/C++");
         break;
     case OPENSEA_COMPILER_IBM_SYSTEMZ_C_CPP:
-        printf("IBM XL C/C++ for SystemZ");
+        print_str("IBM XL C/C++ for SystemZ");
         break;
     case OPENSEA_COMPILER_HP_A_CPP:
-        printf("HP aCC");
+        print_str("HP aCC");
         break;
     case OPENSEA_COMPILER_UNKNOWN:
         // default:
-        printf("Unknown Compiler");
+        print_str("Unknown Compiler");
         break;
     }
 }

--- a/src/error_translation.c
+++ b/src/error_translation.c
@@ -10,8 +10,8 @@
 //! This software is subject to the terms of the Mozilla Public License, v. 2.0.
 //! If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "constraint_handling.h"
 #include "error_translation.h"
+#include "constraint_handling.h"
 #include "memory_safety.h"
 #include "string_utils.h"
 #include "type_conversion.h"
@@ -32,7 +32,7 @@ RESTORE_WARNING_4255
 
 #define ERROR_STRING_BUFFER_LENGTH SIZE_T_C(1024)
 
-char *get_strerror(errno_t error)
+char* get_strerror(errno_t error)
 {
 #if defined(HAVE_C11_ANNEX_K)
     size_t errorStringLen = strerrorlen_s(error);
@@ -67,7 +67,7 @@ char *get_strerror(errno_t error)
         }
         else
         {
-            safe_free(errorString);
+            safe_free(&errorString);
             return M_NULLPTR;
         }
     }
@@ -95,13 +95,14 @@ char *get_strerror(errno_t error)
     {
         if (0 == strerror_r(error, errorString, ERROR_STRING_BUFFER_LENGTH))
         {
-            errorString[ERROR_STRING_BUFFER_LENGTH - SIZE_T_C(1)] = '\0'; // While it should be null terminated, there are
-                                                                        // known bugs on some systems where it is not!
+            errorString[ERROR_STRING_BUFFER_LENGTH - SIZE_T_C(1)] =
+                '\0'; // While it should be null terminated, there are
+                      // known bugs on some systems where it is not!
             return errorString;
         }
         else
         {
-            safe_free(errorString);
+            safe_free(&errorString);
             return errorString;
         }
     }
@@ -114,17 +115,18 @@ char *get_strerror(errno_t error)
     char* errorStringBuf = M_REINTERPRET_CAST(char*, safe_calloc(ERROR_STRING_BUFFER_LENGTH, sizeof(char)));
     if (errorStringBuf != M_NULLPTR)
     {
-        char* errorString = M_NULLPTR;
+        char*              errorString    = M_NULLPTR;
         eConstraintHandler currentHandler = set_Constraint_Handler(ERR_IGNORE);
-        errno_t duperr = 0;
-        char* errmsg = strerror_r(error, errorStringBuf, ERROR_STRING_BUFFER_LENGTH);
+        errno_t            duperr         = 0;
+        char*              errmsg         = strerror_r(error, errorStringBuf, ERROR_STRING_BUFFER_LENGTH);
         if (errmsg != M_NULLPTR)
         {
-            errorStringBuf[ERROR_STRING_BUFFER_LENGTH - SIZE_T_C(1)] = '\0'; // While it should be null terminated, there are
-                                                                             // known bugs on some systems where it is not!
+            errorStringBuf[ERROR_STRING_BUFFER_LENGTH - SIZE_T_C(1)] =
+                '\0'; // While it should be null terminated, there are
+                      // known bugs on some systems where it is not!
             duperr = safe_strdup(&errorString, errmsg);
             set_Constraint_Handler(currentHandler);
-            safe_free(errorStringBuf);
+            safe_free(&errorStringBuf);
             if (duperr == 0)
             {
                 return errorString;
@@ -136,7 +138,7 @@ char *get_strerror(errno_t error)
         }
         else
         {
-            safe_free(errorStringBuf);
+            safe_free(&errorStringBuf);
             return M_NULLPTR;
         }
     }
@@ -148,10 +150,10 @@ char *get_strerror(errno_t error)
 #        error "Error detection POSIX strerror_r vs GNU strerror_r"
 #    endif
 #else
-    //use safe_strdup after disabling abort due to null to make this simpler code.
-    char* errorString = M_NULLPTR;
+    // use safe_strdup after disabling abort due to null to make this simpler code.
+    char*              errorString    = M_NULLPTR;
     eConstraintHandler currentHandler = set_Constraint_Handler(ERR_IGNORE);
-    errno_t duperr = safe_strdup(&errorString, strerror(error));
+    errno_t            duperr         = safe_strdup(&errorString, strerror(error));
     set_Constraint_Handler(currentHandler);
     if (0 == duperr)
     {
@@ -166,11 +168,11 @@ char *get_strerror(errno_t error)
 
 void print_Errno_To_Screen(errno_t error)
 {
-    char *errormsg = get_strerror(error);
+    char* errormsg = get_strerror(error);
     if (errormsg != M_NULLPTR)
     {
         printf("%d - %s\n", error, errormsg);
-        safe_free(errormsg);
+        safe_free(&errormsg);
     }
     else
     {

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -504,7 +504,7 @@ eReturnValues get_Secure_User_Input(const char* prompt, char** userInput, size_t
         ret = FAILURE;
     }
     set_Input_Console_Mode(defaultConMode);
-    printf("\n");
+    print_str("\n");
     return ret;
 }
 
@@ -1039,7 +1039,7 @@ void set_Console_Foreground_Background_Colors(eConsoleColors foregroundColor, eC
         if (foregroundColor == CONSOLE_COLOR_DEFAULT && backgroundColor == CONSOLE_COLOR_DEFAULT)
         {
             // reset or normal
-            printf("\033[0m");
+            print_str("\033[0m");
         }
         else
         {
@@ -1135,7 +1135,7 @@ eReturnValues get_Secure_User_Input(const char* prompt, char** userInput, size_t
         {
             fclose_term(term);
         }
-        printf("\n");
+        print_str("\n");
         return FAILURE;
     }
     // now read the input with getline
@@ -1160,14 +1160,14 @@ eReturnValues get_Secure_User_Input(const char* prompt, char** userInput, size_t
         {
             fclose_term(term);
         }
-        printf("\n");
+        print_str("\n");
         return FAILURE;
     }
     if (devtty)
     {
         fclose_term(term);
     }
-    printf("\n");
+    print_str("\n");
 #    elif IS_FREEBSD_VERSION(4, 6, 0) || (defined(__OpenBSD__) && defined OpenBSD2_9)
     // use readpassphrase instead
     // use BUFSIZ buffer as that should be more than enough to read this
@@ -2343,7 +2343,7 @@ void print_Return_Enum(const char* funcName, eReturnValues ret)
     DISABLE_NONNULL_COMPARE
     if (M_NULLPTR == funcName)
     {
-        printf("Unknown function returning: ");
+        print_str("Unknown function returning: ");
     }
     else
     {
@@ -2354,129 +2354,129 @@ void print_Return_Enum(const char* funcName, eReturnValues ret)
     switch (ret)
     {
     case SUCCESS:
-        printf("SUCCESS\n");
+        print_str("SUCCESS\n");
         break;
     case FAILURE:
-        printf("FAILURE\n");
+        print_str("FAILURE\n");
         break;
     case NOT_SUPPORTED:
-        printf("NOT SUPPORTED\n");
+        print_str("NOT SUPPORTED\n");
         break;
     case COMMAND_FAILURE:
-        printf("COMMAND FAILURE\n");
+        print_str("COMMAND FAILURE\n");
         break;
     case IN_PROGRESS:
-        printf("IN PROGRESS\n");
+        print_str("IN PROGRESS\n");
         break;
     case ABORTED:
-        printf("ABORTED\n");
+        print_str("ABORTED\n");
         break;
     case BAD_PARAMETER:
-        printf("BAD PARAMETER\n");
+        print_str("BAD PARAMETER\n");
         break;
     case MEMORY_FAILURE:
-        printf("MEMORY FAILURE\n");
+        print_str("MEMORY FAILURE\n");
         break;
     case OS_PASSTHROUGH_FAILURE:
-        printf("OS PASSTHROUGH FAILURE\n");
+        print_str("OS PASSTHROUGH FAILURE\n");
         break;
     case LIBRARY_MISMATCH:
-        printf("LIBRARY MISMATCH\n");
+        print_str("LIBRARY MISMATCH\n");
         break;
     case FROZEN:
-        printf("FROZEN\n");
+        print_str("FROZEN\n");
         break;
     case PERMISSION_DENIED:
-        printf("PERMISSION DENIED\n");
+        print_str("PERMISSION DENIED\n");
         break;
     case FILE_OPEN_ERROR:
-        printf("FILE OPEN ERROR\n");
+        print_str("FILE OPEN ERROR\n");
         break;
     case WARN_INCOMPLETE_RFTRS:
-        printf("WARNING INCOMPLETE RTFRS\n");
+        print_str("WARNING INCOMPLETE RTFRS\n");
         break;
     case OS_COMMAND_TIMEOUT:
-        printf("COMMAND TIMEOUT\n");
+        print_str("COMMAND TIMEOUT\n");
         break;
     case WARN_NOT_ALL_DEVICES_ENUMERATED:
-        printf("WARNING NOT ALL DEVICES ENUMERATED\n");
+        print_str("WARNING NOT ALL DEVICES ENUMERATED\n");
         break;
     case WARN_INVALID_CHECKSUM:
-        printf("WARN INVALID CHECKSUM\n");
+        print_str("WARN INVALID CHECKSUM\n");
         break;
     case OS_COMMAND_NOT_AVAILABLE:
-        printf("OS COMMAND NOT AVAILABLE\n");
+        print_str("OS COMMAND NOT AVAILABLE\n");
         break;
     case OS_COMMAND_BLOCKED:
-        printf("OS COMMAND BLOCKED\n");
+        print_str("OS COMMAND BLOCKED\n");
         break;
     case COMMAND_INTERRUPTED:
-        printf("COMMAND INTERRUPTED\n");
+        print_str("COMMAND INTERRUPTED\n");
         break;
     case VALIDATION_FAILURE:
-        printf("VALIDATION FAILURE\n");
+        print_str("VALIDATION FAILURE\n");
         break;
     case STRIP_HDR_FOOTER_FAILURE:
-        printf("STRIP HDR FOOTER FAILURE\n");
+        print_str("STRIP HDR FOOTER FAILURE\n");
         break;
     case PARSE_FAILURE:
-        printf("PARSE FAILURE\n");
+        print_str("PARSE FAILURE\n");
         break;
     case INVALID_LENGTH:
-        printf("INVALID LENGTH\n");
+        print_str("INVALID LENGTH\n");
         break;
     case ERROR_WRITING_FILE:
-        printf("ERROR WRITING FILE\n");
+        print_str("ERROR WRITING FILE\n");
         break;
     case TIMEOUT:
-        printf("TIMEOUT\n");
+        print_str("TIMEOUT\n");
         break;
     case OS_TIMEOUT_TOO_LARGE:
-        printf("OS TIMEOUT TOO LARGE\n");
+        print_str("OS TIMEOUT TOO LARGE\n");
         break;
     case PARSING_EXCEPTION_FAILURE:
-        printf("PARSING EXCEPTION FAILURE\n");
+        print_str("PARSING EXCEPTION FAILURE\n");
         break;
     case POWER_CYCLE_REQUIRED:
-        printf("POWER CYCLE REQUIRED\n");
+        print_str("POWER CYCLE REQUIRED\n");
         break;
     case DIR_CREATION_FAILED:
-        printf("DIR CREATION FAILED\n");
+        print_str("DIR CREATION FAILED\n");
         break;
     case FILE_READ_ERROR:
-        printf("FILE READ ERROR\n");
+        print_str("FILE READ ERROR\n");
         break;
     case DEVICE_ACCESS_DENIED:
-        printf("DEVICE ACCESS DENIED\n");
+        print_str("DEVICE ACCESS DENIED\n");
         break;
     case NOT_PARSED:
-        printf("NOT PARSED\n");
+        print_str("NOT PARSED\n");
         break;
     case MISSING_INFORMATION:
-        printf("MISSING INFORMATION\n");
+        print_str("MISSING INFORMATION\n");
         break;
     case TRUNCATED_FILE:
-        printf("TRUNCATED FILE\n");
+        print_str("TRUNCATED FILE\n");
         break;
     case INSECURE_PATH:
-        printf("INSECURE PATH\n");
+        print_str("INSECURE PATH\n");
         break;
     case DEVICE_BUSY:
-        printf("DEVICE BUSY\n");
+        print_str("DEVICE BUSY\n");
         break;
     case DEVICE_INVALID:
-        printf("DEVICE INVALID\n");
+        print_str("DEVICE INVALID\n");
         break;
     case DEVICE_DISCONNECTED:
-        printf("DEVICE DISCONNECTED\n");
+        print_str("DEVICE DISCONNECTED\n");
         break;
     case UNKNOWN:
-        printf("UNKNOWN\n");
+        print_str("UNKNOWN\n");
         break;
         // NO DEFAULT CASE! This will cause warnings when an enum value is not
         // in this switch-case so that it is never out of date!
     }
-    printf("\n");
+    print_str("\n");
 }
 
 #define DATA_LINE_BUFFER_LENGTH (70)

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -3648,3 +3648,30 @@ int impl_snprintf_err_handle(const char* file,
     }
     return n;
 }
+
+errno_t checked_fputs(const char* nofmt, FILE* out)
+{
+    DISABLE_NONNULL_COMPARE
+    if (nofmt == M_NULLPTR || out == M_NULLPTR)
+    {
+        return EINVAL;
+    }
+    RESTORE_NONNULL_COMPARE
+    if (fputs(nofmt, out) == EOF)
+    {
+        errno_t error  = errno;
+        char*   errmsg = get_strerror(error);
+        if (ferror(out))
+        {
+            fprintf(stderr, "fputs failed (stream error): %s\n", errmsg == M_NULLPTR ? "unknown error" : errmsg);
+        }
+        else
+        {
+            fprintf(stderr, "fputs failed (unknown reason): %s\n", errmsg == M_NULLPTR ? "unknown error" : errmsg);
+        }
+        flush_stderr();
+        safe_free(&errmsg);
+        return error;
+    }
+    return 0;
+}

--- a/src/posix_secure_file.c
+++ b/src/posix_secure_file.c
@@ -399,7 +399,7 @@ static bool internal_OS_Is_Directory_Secure(const char* fullpath, unsigned int n
             if (!recurseSecure)
             {
 #    if defined(_DEBUG)
-                printf("recursive link check failed\n");
+                print_str("recursive link check failed\n");
 #    endif
                 secure = false;
                 safe_free(&link);
@@ -421,7 +421,7 @@ static bool internal_OS_Is_Directory_Secure(const char* fullpath, unsigned int n
 
 #if !defined(UEFI_C_SOURCE)
 #    if defined(_DEBUG)
-        printf("Checking UIDs\n");
+        print_str("Checking UIDs\n");
 #    endif
         if ((buf.st_uid != my_uid) && (buf.st_uid != ROOT_UID_VAL))
         {
@@ -432,7 +432,7 @@ static bool internal_OS_Is_Directory_Secure(const char* fullpath, unsigned int n
             if (my_uid == ROOT_UID_VAL)
             {
 #    if defined(_DEBUG)
-                printf("root UID detected, getting user's ID\n");
+                print_str("root UID detected, getting user's ID\n");
 #    endif
                 uid_t sudouid = get_sudo_uid();
 #    if defined(_DEBUG)

--- a/src/safe_qsort.c
+++ b/src/safe_qsort.c
@@ -93,6 +93,9 @@ static M_INLINE char* med3(char* a, char* b, char* c, ctxcomparefn cmp, void* th
                                 : (cmp(b, c, thunk) > 0 ? b : (cmp(a, c, thunk) < 0 ? a : c));
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// Disabling clang-tidy check since this code comes from another author and I do not need to
+// attempt to refactor this - TJE
 errno_t safe_qsort_context_impl(void*        ptr,
                                 rsize_t      count,
                                 rsize_t      size,
@@ -312,3 +315,4 @@ errno_t safe_qsort_context_impl(void*        ptr,
     }
     RESTORE_NONNULL_COMPARE
 }
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -496,7 +496,7 @@ void print_Time_To_Screen(const uint8_t*  years,
         printf(" %" PRIu8 " year", *years);
         if (*years > 1)
         {
-            printf("s");
+            print_str("s");
         }
     }
     if (days && *days > 0)
@@ -504,7 +504,7 @@ void print_Time_To_Screen(const uint8_t*  years,
         printf(" %" PRIu16 " day", *days);
         if (*days > 1)
         {
-            printf("s");
+            print_str("s");
         }
     }
     if (hours && *hours > 0)
@@ -512,7 +512,7 @@ void print_Time_To_Screen(const uint8_t*  years,
         printf(" %" PRIu8 " hour", *hours);
         if (*hours > 1)
         {
-            printf("s");
+            print_str("s");
         }
     }
     if (minutes && *minutes > 0)
@@ -520,7 +520,7 @@ void print_Time_To_Screen(const uint8_t*  years,
         printf(" %" PRIu8 " minute", *minutes);
         if (*minutes > 1)
         {
-            printf("s");
+            print_str("s");
         }
     }
     if (seconds && *seconds > 0)
@@ -528,12 +528,12 @@ void print_Time_To_Screen(const uint8_t*  years,
         printf(" %" PRIu8 " second", *seconds);
         if (*seconds > 1)
         {
-            printf("s");
+            print_str("s");
         }
     }
     if (years || days || hours || minutes || seconds)
     {
-        printf(" ");
+        print_str(" ");
     }
 }
 

--- a/src/windows_secure_file.c
+++ b/src/windows_secure_file.c
@@ -540,7 +540,7 @@ static bool get_System_Volume(char* winSysVol, size_t winSysVolLen)
             if (ENV_VAR_SUCCESS != get_Environment_Variable("SystemDrive", &systemDrive))
             {
 #if defined(_DEBUG)
-                printf("Failed reading the system drive environment variable.\n");
+                print_str("Failed reading the system drive environment variable.\n");
 #endif //_DEBUG
             }
             else

--- a/src/windows_version_detect.c
+++ b/src/windows_version_detect.c
@@ -522,7 +522,7 @@ bool is_Windows_PE(void)
                                           KEY_READ, &keyHandle))
         {
 #if defined(_DEBUG)
-            printf("Found HKLM\\SYSTEM\\CurrentControlSet\\Control\\MiniNT\n");
+            print_str("Found HKLM\\SYSTEM\\CurrentControlSet\\Control\\MiniNT\n");
 #endif
             isWindowsPE = true;
             RegCloseKey(keyHandle);
@@ -533,7 +533,7 @@ bool is_Windows_PE(void)
                                           KEY_READ, &keyHandle))
         {
 #if defined(_DEBUG)
-            printf("Found HKLM\\SYSTEM\\ControlSet001\\Control\\MiniNT\n");
+            print_str("Found HKLM\\SYSTEM\\ControlSet001\\Control\\MiniNT\n");
 #endif
             isWindowsPE = true;
             RegCloseKey(keyHandle);


### PR DESCRIPTION
This cleans up some more clang-tidy warnings.

Major change is printf->print_str function changes for printing strings that are not using format specifiers (%s, %d, etc).

The other large change is the `get_strerror` function which was broken out of the print_errno_to_screen function to something separate we can call as needed.