### PR TITLE
bug: Adding missing bitshifts for the get_Word1, etc functions

### DIFF
--- a/include/bit_manip.h
+++ b/include/bit_manip.h
@@ -128,7 +128,7 @@ extern "C"
     //! \return uint16_t for second lowest 16 bits
     static M_INLINE uint16_t get_Word1_uint64(uint64_t value)
     {
-        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x00000000FFFF0000)));
+        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x00000000FFFF0000)) >> 16);
     }
 
     //! \fn get_Word1_uint32(uint32_t value)
@@ -137,7 +137,7 @@ extern "C"
     //! \return uint16_t for highest 16 bits
     static M_INLINE uint16_t get_Word1_uint32(uint32_t value)
     {
-        return M_STATIC_CAST(uint16_t, (value & UINT32_C(0xFFFF0000)));
+        return M_STATIC_CAST(uint16_t, (value & UINT32_C(0xFFFF0000)) >> 16);
     }
 
 //! \def M_Word1
@@ -155,7 +155,7 @@ extern "C"
     //! \return uint16_t for second highest 16 bits
     static M_INLINE uint16_t get_Word2_uint64(uint64_t value)
     {
-        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x0000FFFF00000000)));
+        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0x0000FFFF00000000)) >> 32);
     }
 
 //! \def M_Word2
@@ -173,7 +173,7 @@ extern "C"
     //! \return uint16_t of the highest 16 bits.
     static M_INLINE uint16_t get_Word3_uint64(uint64_t value)
     {
-        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0xFFFF000000000000)));
+        return M_STATIC_CAST(uint16_t, (value & UINT64_C(0xFFFF000000000000)) >> 48);
     }
 
 //! \def M_Word3

--- a/include/opensea_common_version.h
+++ b/include/opensea_common_version.h
@@ -43,7 +43,7 @@ extern "C"
 
 //! \def OPENSEA_COMMON_PATCH_VERSION
 //! \brief Defines the patch version number for the opensea-common library.
-#define OPENSEA_COMMON_PATCH_VERSION 5
+#define OPENSEA_COMMON_PATCH_VERSION 6
 
 //! \def OPENSEA_COMMON_VERSION
 //! \brief Combines the major, minor, and patch version numbers into a single version string for the opensea-common


### PR DESCRIPTION
These functions should have a bitshift in them to return a non-zero value based on the applied bitmask, but it was missing. This can cause incorrect results where these functions were used.