### PR TITLE
Fix raise_to_power function for positive numbers.

### DIFF
--- a/src/math_utils.c
+++ b/src/math_utils.c
@@ -21,13 +21,25 @@ double raise_to_power(double number, double power)
     {
         return 1.0;
     }
-    if (localPower == INT64_C(1))
+    if (localPower > INT64_C(0))
     {
-        return number;
+        // Positive exponent: multiply number by itself localPower times
+        for (int64_t i = INT64_C(0); i < localPower; i++)
+        {
+            result = result * number;
+        }
     }
-    for (int64_t i = INT64_C(-1); i >= localPower && localPower != INT64_C(0); i--)
+    else
     {
-        result = result * (1.0 / number);
+        // Negative exponent: multiply (1.0/number) by itself |localPower| times
+        if (number == 0.0)
+        {
+            return 0.0 / 0.0; // Division by zero: return NaN
+        }
+        for (int64_t i = INT64_C(0); i < -localPower; i++)
+        {
+            result = result * (1.0 / number);
+        }
     }
     return result;
 }

--- a/src/math_utils.c
+++ b/src/math_utils.c
@@ -12,34 +12,9 @@
 
 #include "math_utils.h"
 #include "type_conversion.h"
+#include <math.h>
 
 double raise_to_power(double number, double power)
 {
-    double  result     = 1.0;
-    int64_t localPower = C_CAST(int64_t, power);
-    if (localPower == INT64_C(0))
-    {
-        return 1.0;
-    }
-    if (localPower > INT64_C(0))
-    {
-        // Positive exponent: multiply number by itself localPower times
-        for (int64_t i = INT64_C(0); i < localPower; i++)
-        {
-            result = result * number;
-        }
-    }
-    else
-    {
-        // Negative exponent: multiply (1.0/number) by itself |localPower| times
-        if (number == 0.0)
-        {
-            return 0.0 / 0.0; // Division by zero: return NaN
-        }
-        for (int64_t i = INT64_C(0); i < -localPower; i++)
-        {
-            result = result * (1.0 / number);
-        }
-    }
-    return result;
+    return pow(number, power);
 }


### PR DESCRIPTION
Issue: raise_to_power function was not working for positive number.

Fix: 
1. Use pow() function from math.h
2. It handles all the cases. We already added math.h in other opensea-common files so adding it here also.
