### PR TITLE
bug: Adding missing include for stdarg to fix compilation errors for …

### DIFF
--- a/include/impl_io_utils.h
+++ b/include/impl_io_utils.h
@@ -22,6 +22,7 @@
 #include "type_conversion.h"
 
 #include <stdio.h>
+#include <stdarg.h>
 
 #if defined(__cplusplus)
 extern "C"


### PR DESCRIPTION
…va_list

va_list is defined in stdarg.h so adding that include to handle the safe_vsnprinf implementation in impl_io_utils.h